### PR TITLE
Bump ngx_lua version to 0.9.16

### DIFF
--- a/Formula/ngx_openresty.rb
+++ b/Formula/ngx_openresty.rb
@@ -43,8 +43,8 @@ class NgxOpenresty < Formula
     # Download the ssl-cert-by-lua branch and add ssl.lua to the lua_package_path
     system "curl -s -L -o #{buildpath}/ssl-cert-by-lua.tar.gz https://github.com/openresty/lua-nginx-module/archive/ssl-cert-by-lua.tar.gz"
     system "tar -xzf ssl-cert-by-lua.tar.gz"
-    system "rm -rf bundle/ngx_lua-0.9.15/*"
-    system "cp -R lua-nginx-module-ssl-cert-by-lua/* bundle/ngx_lua-0.9.15/"
+    system "rm -rf bundle/ngx_lua-0.9.16/*"
+    system "cp -R lua-nginx-module-ssl-cert-by-lua/* bundle/ngx_lua-0.9.16/"
 
     system "./configure", *args
     system "make"


### PR DESCRIPTION
Hi,

This fixes issue #3. Apparently the *ssl-cert-by-lua* branch was updated at some point, breaking the build.