### PR TITLE
fix: empty installation error

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -20,6 +20,10 @@ class Kong < Formula
   depends_on "cassandra" => :optional
 
   def install
-    system "make install"
+    system "make", "install"
+    # hack: to avoid the empty installation error, we override the kong script installed by
+    # luarocks in 'make install' with a proper symlink from this Formula.
+    rm "#{HOMEBREW_PREFIX}/bin/kong"
+    bin.install "bin/kong"
   end
 end


### PR DESCRIPTION
Since https://github.com/Homebrew/homebrew/pull/47678, the detection for
empty installations is more severe and made this Formula break. A
comment explains the fix.