### PR TITLE
fix(kong) patch Kong's default prefix to `/urs/local/opt/kong`

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -7,12 +7,14 @@ class Kong < Formula
   end
 
   devel do
-    url "https://github.com/mashape/kong.git", :tag => "0.11.0rc1"
+    url "https://github.com/Mashape/kong.git", :tag => "0.11.0rc1"
   end
 
   head do
     url "https://github.com/Mashape/kong.git", :branch => "next"
   end
+
+  patch :DATA
 
   depends_on "openssl"
   depends_on "serf"
@@ -24,3 +26,18 @@ class Kong < Formula
     bin.install "bin/kong"
   end
 end
+
+# patch Kong default `prefix` to `/usr/local/opt/kong` as `/usr/local/` 
+# not writable by non root user on OSX
+__END__
+diff --git a/kong/templates/kong_defaults.lua b/kong/templates/kong_defaults.lua
+index e38b475..7a74a2f 100644
+--- a/kong/templates/kong_defaults.lua
++++ b/kong/templates/kong_defaults.lua
+@@ -1,5 +1,5 @@
+ return [[
+-prefix = /usr/local/kong/
++prefix = /usr/local/opt/kong/
+ log_level = notice
+ proxy_access_log = logs/access.log
+ proxy_error_log = logs/error.log


### PR DESCRIPTION
Interim solution for `permission denied` while creating default
prefix directory `/usr/local/kong` when non root user start Kong
on OSX.