### PR TITLE
fix(luarocks) set rocks location to kong's Cellar

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -22,7 +22,7 @@ class Kong < Formula
   depends_on "mashape/kong/luarocks"
 
   def install
-    system "luarocks make OPENSSL_DIR=#{Formula['openssl'].opt_prefix}"
+    system "luarocks-5.1 --tree=#{prefix} make OPENSSL_DIR=#{Formula['openssl'].opt_prefix}"
     bin.install "bin/kong"
   end
 end

--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -4,29 +4,45 @@ class Luarocks < Formula
   sha256 "0e1ec34583e1b265e0fbafb64c8bd348705ad403fe85967fd05d3a659f74d2e5"
   head "https://github.com/keplerproject/luarocks.git"
 
+  patch :DATA
+
   depends_on "mashape/kong/openresty"
 
   def install
     openresty = Formula["mashape/kong/openresty"]
 
-    # Install to the Cellar, but the tree to install modules is in HOMEBREW_PREFIX
+    # Install to the Cellar, but the tree to install modules is in HOMEBREW_PREFIX/opt/kong
     args = [
       "--prefix=#{prefix}",
-      "--rocks-tree=#{openresty.prefix}/luajit",
+      "--rocks-tree=#{HOMEBREW_PREFIX}/opt/kong",
       "--sysconfdir=#{prefix}/etc",
       "--with-lua=#{openresty.prefix}/luajit",
       "--with-lua-include=#{openresty.prefix}/luajit/include/luajit-2.1",
       "--lua-suffix=jit"
     ]
 
+    ENV.deparallelize
     system "./configure", *args
     system "make build"
     system "make install"
-    system "#{bin}/luarocks install luarocks"
   end
 
   def caveats; <<-EOS.undent
-    Rocks will be installed to: <OPENRESTY_PREFIX>/luajit
+    Rocks will be installed to: #{HOMEBREW_PREFIX}/opt/kong
     EOS
   end
 end
+# Do not attempt to create the rocks tree prefix directory,
+# since /usr/local/opt/kong lies outside of our sandbox.
+__END__
+diff -u a/luarocks-2.4.2/Makefile b/luarocks-2.4.2/Makefile
+--- luarocks-2.4.2/Makefile	2016-11-30 04:49:34.000000000 -0800
++++ luarocks-2.4.2-new/Makefile	2017-08-03 14:54:45.000000000 -0700
+@@ -133,7 +133,6 @@
+ 	cp src/luarocks/site_config.lua "$(DESTDIR)$(LUADIR)/luarocks"
+ 
+ write_sysconfig:
+-	mkdir -p "$(DESTDIR)$(ROCKS_TREE)"
+ 	if [ ! -f "$(DESTDIR)$(CONFIG_FILE)" ] ;\
+ 	then \
+ 	   mkdir -p `dirname "$(DESTDIR)$(CONFIG_FILE)"` ;\


### PR DESCRIPTION
* Configure LuaRocks to use /usr/local/opt/kong as a target
  for installing rocks. Homebrew uses the macOS `sandbox-exec`
  feature, so a formula can only install files into its own
  Cellar. After `brew install kong` is done, the user can
  Install extra rocks directly with `luarocks install` and
  these will go into /usr/local/opt/kong without
  permission problems because there is no sandbox in place.
* We patch the LuaRocks Makefile because it tries to create
  the directory for the rocks tree, which lies outside its
  own sandbox. Since this LuaRocks formula is used only as
  a dependency for the `kong` formula and this directory is
  created by `brew install kong`, we can just delete this command.
* The kong.rb formula uses `--tree` explicitly to install into
  the Cellar directory, because at this point /usr/local/opt/kong
  does not exist yet. Once `brew install kong` finishes,
  /usr/local/opt/kong points to the contents of kong's Cellar,
  so the rocks installed here end up in the location LuaRocks
  was configured to use.
* We use `luarocks-5.1` explicitly to avoid any potential conflict
  with the `luarocks` package from homebrew-core, which installs
  LuaRocks for Lua 5.2.

This is all in one patch because the changes are interdependent.