### PR TITLE
release: 0.11.0

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -3,12 +3,13 @@ class Kong < Formula
   desc "Open source Microservices and API Gateway"
 
   stable do
-    url "https://github.com/Mashape/kong.git", :tag => "0.10.3"
+    url "https://bintray.com/kong/kong-community-edition-src/download_file?file_path=kong-community-edition-0.11.0.tar.gz"
+    sha256 "50305f52075d96b5b7ab3a051611bf7f28d263d7d45e2004572d9d3ef0ef8141"
   end
 
-  devel do
-    url "https://github.com/Mashape/kong.git", :tag => "0.11.0rc2"
-  end
+  #devel do
+  #  url "https://github.com/Mashape/kong.git", :tag => "0.11.0rc2"
+  #end
 
   head do
     url "https://github.com/Mashape/kong.git", :branch => "next"
@@ -17,7 +18,6 @@ class Kong < Formula
   patch :DATA
 
   depends_on "openssl"
-  depends_on "serf"
   depends_on "mashape/kong/openresty"
   depends_on "mashape/kong/luarocks"
 

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -2,8 +2,8 @@ class Openresty < Formula
   homepage "https://openresty.org/"
 
   stable do
-    url "https://openresty.org/download/openresty-1.11.2.2.tar.gz"
-    sha256 "7f9ca62cfa1e4aedf29df9169aed0395fd1b90de254139996e554367db4d5a01"
+    url "https://openresty.org/download/openresty-1.11.2.4.tar.gz"
+    sha256 "07679171450a6c083f983f6130056de3c4e13cc2d117dea68e1c6990e2e49ac9"
   end
 
   depends_on "pcre"
@@ -19,7 +19,6 @@ class Openresty < Formula
       "--with-http_ssl_module",
       "--with-http_realip_module",
       "--with-http_stub_status_module",
-      "--without-luajit-lua52",
       "--with-cc-opt=-I#{HOMEBREW_PREFIX}/include,#{HOMEBREW_PREFIX}/opt/openssl/include",
       "--with-ld-opt=-L#{HOMEBREW_PREFIX}/lib,#{HOMEBREW_PREFIX}/opt/openssl/lib",
       "-j#{ENV.make_jobs}"


### PR DESCRIPTION
* remove Serf dependency
* bump OpenResty to 1.11.2.4
* remove --without-luajit-lua52 OpenResty flag
* disable --devel installs (drop 0.11.0rc2 support)

TODO:
- [x] update Kong repo and/or tag to point to `0.11.0` release